### PR TITLE
Make heat pump type a selection item in config flow

### DIFF
--- a/custom_components/thermiagenesis/config_flow.py
+++ b/custom_components/thermiagenesis/config_flow.py
@@ -1,4 +1,5 @@
 """Adds config flow for ThermiaGenesis heat pump."""
+from enum import Enum
 import logging
 
 import voluptuous as vol
@@ -6,6 +7,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST
 from homeassistant.const import CONF_PORT
 from homeassistant.const import CONF_TYPE
+from homeassistant.helpers.selector import selector
 from pythermiagenesis import ThermiaConnectionError
 from pythermiagenesis import ThermiaGenesis
 from pythermiagenesis.const import ATTR_COIL_ENABLE_HEAT
@@ -58,7 +60,11 @@ class ThermiaGenesisConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CONF_HOST, default=defaults[CONF_HOST]): str,
                     vol.Required(CONF_PORT, default=defaults[CONF_PORT]): int,
-                    vol.Required(CONF_TYPE, default=defaults[CONF_TYPE]): str,
+                    vol.Required(CONF_TYPE, default=defaults[CONF_TYPE]): selector({
+                        "select": {
+                            "options": ["inverter", "mega"],
+                        }
+                    })
                 }
             ),
             errors=self._errors,


### PR DESCRIPTION
This PR has two minor changes. If you'd prefer two separate PRs instead, I'm happy to do that as well!

First, the translation files present in the component cause issues at least when the English language UI is used (lots of translation errors instead of intended strings). Since the translation files don't really do anything at the moment, I removed them altogether.

Second, in the initial config flow, the heat pump type (inverter vs mega) is now a selection item (radio buttons) instead of a free-form string field.