### PR TITLE
Read 16 registers to increase performance.

### DIFF
--- a/custom_components/thermiagenesis/__init__.py
+++ b/custom_components/thermiagenesis/__init__.py
@@ -77,7 +77,7 @@ class ThermiaGenesisDataUpdateCoordinator(DataUpdateCoordinator):
     def __init__(self, hass, host, port, kind):
         """Initialize."""
         self.thermia = ThermiaGenesis(
-            host, port=port, kind=kind, delay=0.05, max_registers=1
+            host, port=port, kind=kind, delay=0.05, max_registers=16
         )
         self.kind = kind
         self.attributes = {}


### PR DESCRIPTION
I have not researched whether this is true in the dependent library, but feels like a performance hit to only read 1 register?